### PR TITLE
fix too many values to unpack

### DIFF
--- a/xcauth.py
+++ b/xcauth.py
@@ -422,7 +422,7 @@ class xcauth:
 
 def verify_with_isuser(url, secret, domain, user, timeout):
     xc = xcauth(default_url=url, default_secret=secret, timeout=timeout)
-    success, code, response = xc.verbose_cloud_request({
+    success, code, response, text = xc.verbose_cloud_request({
         'operation': 'isuser',
         'username':  user,
         'domain':    domain


### PR DESCRIPTION
`verbose_cloud_request` returns a quad tuble:

```
return True, None, r.json(), r.text
```

which results in the error `too many values to unpack`

fix jsxc/jsxc#596