### PR TITLE
'str' object has no attribute 'decode'

### DIFF
--- a/xclib/utf8.py
+++ b/xclib/utf8.py
@@ -16,8 +16,11 @@ def unutf8(u, opts='strict'):
             traceback.print_exc()
             return 'illegal-utf8-sequence-' + dec
     else:
-        return u.decode('utf-8', opts)
-
+        try:
+            return u.decode('utf-8', opts)
+        except AttributeError:
+            pass
+        
 def utf8l(l):
     '''Encode a copy of the list, converted to UTF-8'''
     return list(map(utf8, l))


### PR DESCRIPTION
I am trying to use user caching, after setting "cache-storage=db" I am getting

```
File "/usr/lib/python3/dist-packages/xclib/utf8.py", line 19, in unutf8
    return u.decode('utf-8', opts)
AttributeError: 'str' object has no attribute 'decode'
```
It seems like the object is already decoded.
With this fix I was able to successfully enable user caching.